### PR TITLE
JSON: fail on errors in json

### DIFF
--- a/sztp-agent/pkg/secureAgent/daemon.go
+++ b/sztp-agent/pkg/secureAgent/daemon.go
@@ -8,6 +8,7 @@ Copyright (C) 2022 Red Hat.
 package secureAgent
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/asn1"
 	"encoding/base64"
@@ -127,9 +128,11 @@ func (a *Agent) doRequestBootstrapServerOnboardingInfo() error {
 	// TODO: conveyed-info can be either redirect-information or onboarding-information
 	//		 so decode using BootstrapServerRedirectInfo or BootstrapServerOnboardingInfo
 	var oi BootstrapServerOnboardingInfo
-	derr := json.Unmarshal(data.Bytes, &oi)
-	if derr != nil {
-		return derr
+
+	decoder := json.NewDecoder(bytes.NewReader(data.Bytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&oi); err != nil {
+		return err
 	}
 	res.IetfSztpBootstrapServerOutput.ConveyedInformation = string(data.Bytes)
 	a.BootstrapServerOnboardingInfo = oi

--- a/sztp-agent/pkg/secureAgent/daemon_test.go
+++ b/sztp-agent/pkg/secureAgent/daemon_test.go
@@ -48,7 +48,7 @@ func TestAgent_RunCommandDaemon(t *testing.T) {
 }
 
 func TestAgent_getBootstrapURL(t *testing.T) {
-	dhcpTestFileOK := "./test.dhcp"
+	dhcpTestFileOK := "/tmp/test.dhcp"
 	createTempTestFile(dhcpTestFileOK, true)
 
 	type fields struct {

--- a/sztp-agent/pkg/secureAgent/utils_test.go
+++ b/sztp-agent/pkg/secureAgent/utils_test.go
@@ -91,7 +91,7 @@ func Test_extractfromLine(t *testing.T) {
 }
 
 func Test_linesInFileContains(t *testing.T) {
-	dhcpTestFileOK := "./test.dhcp"
+	dhcpTestFileOK := "/tmp/test.dhcp"
 	createTempTestFile(dhcpTestFileOK, true)
 	type args struct {
 		file   string


### PR DESCRIPTION
Also allow testing like this:
```
docker run --rm -it -e CGO_ENABLED=0 -v `pwd`:/app -w /app golang:alpine go test -v /app/...
```
Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
