### PR TITLE
ci: build clients AFTER servers

### DIFF
--- a/.github/workflows/sztp.yml
+++ b/.github/workflows/sztp.yml
@@ -19,7 +19,46 @@ concurrency:
 
 jobs:
 
+  sztp-server-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - sztp-server
+    steps:
+    - uses: actions/checkout@v3
+    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-buildx-action@7932f6210d7d60bffb2f9bcfa60e9e2c4800d96d
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@3da7dc6e2b31f99ef2cb9fb4c50fb0971e0d0139
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@6c3ca5dfa6895029f82e5b2f26f060bc0d3c6a2c
+      with:
+        images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/opi-${{ matrix.package }}
+
+    - name: Build and push Docker image
+      id: build-and-push
+      uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
+      with:
+        context: ${{ matrix.package }}
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
   sztp-push:
+    needs: sztp-server-push
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -28,7 +67,6 @@ jobs:
           - dhcp-client
           - dhcp-server
           - sztp-agent
-          - sztp-server
           - sztp-simulator
           - web
     steps:


### PR DESCRIPTION
Since client refence the server image during build:
```
COPY --from=ghcr.io/opiproject/opi-sztp-server:main
```

we need to build server first to make publish work correctly.

the problem was not showing during normal compose builds

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
