### PR TITLE
feat: add script to fetch bootstrap logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       context: sztp-server
     environment:
       SZTPD_INIT_PORT: 6080
-      SZTPD_NBI_PORT: 7080
+      SZTPD_NBI_PORT: 7070
       SZTPD_SBI_PORT: 8080
       SZTPD_INIT_MODE: 1
       SZTPD_ACCEPT_CONTRACT: "Yes"

--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
+
+set -euxo pipefail
+
+# docker compose plugin
+command -v docker-compose || { shopt -s expand_aliases && alias docker-compose='docker compose'; }
+
+# let everything start
+sleep 5
+
+# print for debug
+docker-compose ps
+
+# check bootstrapping log
+docker-compose exec -T bootstrap curl -i -X GET --user my-admin@example.com:my-secret  -H "Accept:application/yang-data+json" http://bootstrap:7080/restconf/ds/ietf-datastores:operational/wn-sztpd-1:devices/device=my-serial-number/bootstrapping-log
+
+echo "DONE"

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -29,7 +29,7 @@ docker-compose exec -T client cat /var/lib/dhclient/dhclient.leases | grep sztp-
 REDIRECT=$(docker-compose exec -T client cat /var/lib/dhclient/dhclient.leases | grep sztp-redirect-urls | head -n 1 | awk '{print $3}' | tr -d '";')
 
 # read back to check configuration was set
-docker-compose exec -T bootstrap curl -i --user my-admin@example.com:my-secret -H "Accept:application/yang-data+json" http://redirecter:7080/restconf/ds/ietf-datastores:running
+docker-compose exec -T redirecter curl -i --user my-admin@example.com:my-secret -H "Accept:application/yang-data+json" http://redirecter:7070/restconf/ds/ietf-datastores:running
 
 # request onboarding info (like a DPU or IPU device would) and see it is redirect
 docker-compose run -T agent curl -X POST --data @/tmp/input.json -H "Content-Type:application/yang-data+json" --user my-serial-number:my-secret --key /private_key.pem --cert /my_cert.pem --cacert /opi.pem "${REDIRECT}" | tee /tmp/post_rpc_input.json

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -21,7 +21,7 @@ sleep 5
 
 # tests mDNS client
 docker-compose run --rm -T nmapmdnsclient
-docker-compose run --rm -T nmapmdnsclient | grep sztp_avahi_1.sztp_opi
+docker-compose run --rm -T nmapmdnsclient | grep sztp_opi
 
 # tests dhcp client
 docker-compose exec -T client cat /var/lib/dhclient/dhclient.leases


### PR DESCRIPTION
- fix: 7080 was used for both redirecter and bootstrap
- feat: add script to fetch bootstrap logs
