### PR TITLE
test: add 401 wrong auth test

### DIFF
--- a/sztp-agent/pkg/secureagent/agent.go
+++ b/sztp-agent/pkg/secureagent/agent.go
@@ -156,6 +156,16 @@ type BootstrapServerPostOutput struct {
 	} `json:"ietf-sztp-bootstrap-server:output"`
 }
 
+type BootstrapServerErrorOutput struct {
+	IetfRestconfErrors struct {
+		Error []struct {
+			ErrorType    string `json:"error-type"`
+			ErrorTag     string `json:"error-tag"`
+			ErrorMessage string `json:"error-message"`
+		} `json:"error"`
+	} `json:"ietf-restconf:errors"`
+}
+
 // Agent is the basic structure to define an agent instance
 type Agent struct {
 	BootstrapURL                  string                        // Bootstrap complete URL

--- a/sztp-agent/pkg/secureagent/daemon_test.go
+++ b/sztp-agent/pkg/secureagent/daemon_test.go
@@ -148,6 +148,27 @@ func TestAgent_doReqBootstrap(t *testing.T) {
 			ConveyedInformation: "{wrongBASE64}",
 		},
 	}
+	expectedError := BootstrapServerErrorOutput{
+		IetfRestconfErrors: struct {
+			Error []struct {
+				ErrorType    string `json:"error-type"`
+				ErrorTag     string `json:"error-tag"`
+				ErrorMessage string `json:"error-message"`
+			} `json:"error"`
+		}{
+			Error: []struct {
+				ErrorType    string `json:"error-type"`
+				ErrorTag     string `json:"error-tag"`
+				ErrorMessage string `json:"error-message"`
+			}{
+				{
+					ErrorType:    "protocol",
+					ErrorTag:     "access-denied",
+					ErrorMessage: "failed",
+				},
+			},
+		},
+	}
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user, pass, _ := r.BasicAuth()
 		log.Println(user, pass)
@@ -162,6 +183,9 @@ func TestAgent_doReqBootstrap(t *testing.T) {
 		case (user + ":" + pass) == "KOBASE64:KO":
 			w.WriteHeader(200)
 			output, _ = json.Marshal(expectedFailedBase64)
+		case (user + ":" + pass) == "KO:KO":
+			w.WriteHeader(401)
+			output, _ = json.Marshal(expectedError)
 		default:
 			w.WriteHeader(400)
 			output, _ = json.Marshal(expectedOnboarding)


### PR DESCRIPTION
from ci:
```
#18 12.45 === RUN   TestAgent_doReqBootstrap/Test_KO_getting_error_with_basic_auth
#18 12.45 2024/06/05 01:21:17 [INFO] Starting the Request to get On-boarding Information.
#18 12.45 2024/06/05 01:21:17 KO KO
#18 12.45 2024/06/05 01:21:17 [ERROR]  json: unknown field "ietf-restconf:errors"
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
