### PR TITLE
refactor: fix go imports after rename

### DIFF
--- a/sztp-agent/cmd/daemon_test.go
+++ b/sztp-agent/cmd/daemon_test.go
@@ -3,9 +3,10 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNewDaemonCommand(t *testing.T) {

--- a/sztp-agent/cmd/disable_test.go
+++ b/sztp-agent/cmd/disable_test.go
@@ -3,9 +3,10 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNewDisableCommand(t *testing.T) {

--- a/sztp-agent/cmd/enable_test.go
+++ b/sztp-agent/cmd/enable_test.go
@@ -3,9 +3,10 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNewEnableCommand(t *testing.T) {

--- a/sztp-agent/cmd/run_test.go
+++ b/sztp-agent/cmd/run_test.go
@@ -3,9 +3,10 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNewRunCommand(t *testing.T) {

--- a/sztp-agent/cmd/status_test.go
+++ b/sztp-agent/cmd/status_test.go
@@ -3,9 +3,10 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNewStatusCommand(t *testing.T) {

--- a/sztp-agent/main.go
+++ b/sztp-agent/main.go
@@ -11,9 +11,10 @@ import (
 	"github.com/TwiN/go-color"
 	"github.com/opiproject/sztp/sztp-agent/cmd"
 
-	"github.com/spf13/cobra"
 	"log"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 func main() {

--- a/sztp-agent/pkg/secureagent/daemon.go
+++ b/sztp-agent/pkg/secureagent/daemon.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/github/smimesign/ietf-cms/protocol"
 	"io"
 	"log"
 	"net/http"
@@ -27,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/github/smimesign/ietf-cms/protocol"
 )
 
 const (

--- a/sztp-agent/pkg/secureagent/utils.go
+++ b/sztp-agent/pkg/secureagent/utils.go
@@ -14,7 +14,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"github.com/jaypipes/ghw"
 	"io"
 	"log"
 	"net/http"
@@ -22,6 +21,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/jaypipes/ghw"
 )
 
 // Auxiliar function to get lines from file matching with the substr


### PR DESCRIPTION
/app # go install golang.org/x/tools/cmd/goimports@latest
/app # goimports -w /app

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
