### PR TITLE
fix: move certs from build to runtime

### DIFF
--- a/sztp-server/Dockerfile
+++ b/sztp-server/Dockerfile
@@ -30,21 +30,12 @@ COPY images/ /media/
 
 # hadolint ignore=SC2016
 RUN \
-    SBI_PRI_KEY_B64=`openssl enc -base64 -A -in sztpd1/sbi/end-entity/private_key.der` \
-    SBI_PUB_KEY_B64=`openssl enc -base64 -A -in sztpd1/sbi/end-entity/public_key.der` \
-    SBI_EE_CERT_B64=`openssl enc -base64 -A -in /tmp/cert_chain.cms` \
-    BOOTSVR_TA_CERT_B64=`openssl enc -base64 -A -in /tmp/ta_cert_chain.cms` \
-    CLIENT_CERT_TA_B64=`openssl enc -base64 -A -in /tmp/ta_cert_chain.cms` \
-    envsubst '$CLIENT_CERT_TA_B64,$SBI_PRI_KEY_B64,$SBI_PUB_KEY_B64,$SBI_EE_CERT_B64,$BOOTSVR_TA_CERT_B64' < /tmp/sztpd.redirect.json.template > /tmp/redirect.json.static && \
+    cp /tmp/sztpd.redirect.json.template /tmp/redirect.json.images && \
     BOOT_IMG_HASH_VAL=`openssl dgst -sha256 -c /media/my-boot-image.img | awk '{print $2}'` \
     PRE_SCRIPT_B64=`openssl enc -base64 -A -in /tmp/my-pre-configuration-script.sh` \
     POST_SCRIPT_B64=`openssl enc -base64 -A -in /tmp/my-post-configuration-script.sh` \
     CONFIG_B64=`openssl enc -base64 -A -in /tmp/my-configuration.xml` \
-    SBI_PRI_KEY_B64=`openssl enc -base64 -A -in sztpd1/sbi/end-entity/private_key.der` \
-    SBI_PUB_KEY_B64=`openssl enc -base64 -A -in sztpd1/sbi/end-entity/public_key.der` \
-    SBI_EE_CERT_B64=`openssl enc -base64 -A -in /tmp/cert_chain.cms` \
-    CLIENT_CERT_TA_B64=`openssl enc -base64 -A -in /tmp/ta_cert_chain.cms` \
-    envsubst '$BOOT_IMG_HASH_VAL,$PRE_SCRIPT_B64,$POST_SCRIPT_B64,$CONFIG_B64,$CLIENT_CERT_TA_B64,$SBI_PRI_KEY_B64,$SBI_PUB_KEY_B64,$SBI_EE_CERT_B64' < /tmp/sztpd.running.json.template > /tmp/running.json.static
+    envsubst '$BOOT_IMG_HASH_VAL,$PRE_SCRIPT_B64,$POST_SCRIPT_B64,$CONFIG_B64' < /tmp/sztpd.running.json.template > /tmp/running.json.images
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
This allows to change certs in runtime

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
