### PR TITLE
Closes #400

### DIFF
--- a/sztp-agent/cmd/systemd.go
+++ b/sztp-agent/cmd/systemd.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/opiproject/sztp/sztp-agent/pkg/secureagent"
+	"github.com/spf13/cobra"
+)
+
+// NewSystemdCommand NewEnableCommand returns the enable command
+func NewSystemdCommand() *cobra.Command {
+	var (
+		path    string
+		options string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "systemd",
+		Short: "Create a templated systemd unit file for sztp-agent",
+		RunE: func(c *cobra.Command, _ []string) error {
+			err := secureagent.CreateUnitFile(options, path)
+			return err
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&path, "path", "p", "/etc/systemd/system",
+		"Path for unit file to be created")
+	flags.StringVarP(&options, "options", "o", "",
+		"sztp-agent args/flags to add into the unit file")
+	return cmd
+}

--- a/sztp-agent/cmd/systemd_test.go
+++ b/sztp-agent/cmd/systemd_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"reflect"
+	"testing"
+)
+
+func TestSystemdCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		want *cobra.Command
+	}{
+		{
+			name: "TestSystemdCommand",
+			want: &cobra.Command{
+				Use:   "systemd",
+				Short: "Create a template systemd unit file",
+				RunE: func(c *cobra.Command, _ []string) error {
+					err := c.Help()
+					cobra.CheckErr(err)
+					return nil
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewSystemdCommand(""); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
+				t.Errorf("NewStatusCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sztp-agent/pkg/secureagent/systemd.go
+++ b/sztp-agent/pkg/secureagent/systemd.go
@@ -1,0 +1,36 @@
+package secureagent
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+const unitFile = "sztp-agent.service"
+
+func CreateUnitFile(execOptions string, path string) error {
+	path = strings.TrimSuffix(path, "/") + "/" + unitFile // ensures no double trailing slashes
+	contents := fmt.Sprintf(`[Unit]
+Description=SZTP Agent
+After=network.target
+
+[Service]
+ExecStart=opi-sztp-agent %[1]s
+ExecReload=opi-sztp-agent %[1]s
+Type=notify
+Restart=always
+
+[Install]
+WantedBy=default.target
+RequiredBy=network.target
+`, execOptions)
+
+	err := os.WriteFile(path, []byte(contents), 0644)
+	if err != nil {
+		return fmt.Errorf("creating unit file %s: %v", path, err)
+	}
+
+	log.Printf("Unit file %s created successfully. Ensure sztp-agent binary is installed on your system", path+"")
+	return nil
+}

--- a/sztp-agent/pkg/secureagent/systemd_test.go
+++ b/sztp-agent/pkg/secureagent/systemd_test.go
@@ -16,8 +16,8 @@ Description=SZTP Agent
 After=network.target
 
 [Service]
-ExecStart=sztp-agent %[1]s
-ExecReload=sztp-agent %[1]s
+ExecStart=opi-sztp-agent %[1]s
+ExecReload=opi-sztp-agent %[1]s
 Type=notify
 Restart=always
 

--- a/sztp-agent/pkg/secureagent/systemd_test.go
+++ b/sztp-agent/pkg/secureagent/systemd_test.go
@@ -1,0 +1,44 @@
+package secureagent
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestCreateUnitFile(t *testing.T) {
+	const testOptions = "-bogus -options"
+	const unitFilePath = "/tmp"
+
+	contents := fmt.Sprintf(`[Unit]
+Description=SZTP Agent
+After=network.target
+
+[Service]
+ExecStart=sztp-agent %[1]s
+ExecReload=sztp-agent %[1]s
+Type=notify
+Restart=always
+
+[Install]
+WantedBy=default.target
+RequiredBy=network.target
+`, testOptions)
+
+	CreateUnitFile(testOptions, unitFilePath)
+
+	b, err := os.ReadFile(unitFilePath + "/" + unitFile)
+	if err != nil {
+		t.Errorf("Error reading unit file %s: %v", unitFilePath, err)
+	}
+
+	if !bytes.Equal(b, []byte(contents)) {
+		t.Errorf("Bytes do not match for contents and written unit file %s", unitFilePath)
+	}
+
+	err = os.Remove(unitFilePath + "/" + unitFile)
+	if err != nil {
+		t.Errorf("Error deleting unit file %s: %v", unitFilePath, err)
+	}
+}


### PR DESCRIPTION
For some reason, I'm unable to link issues in the title, but it's here: #400 

I've created a very basic and standard unit file for now. If there are any additions or changes to the unit file, let me know.

The user has the possibility to specify the path of where the unit file gets created, and/or options to go with the built binary inside the unit file. Otherwise it defaults to no args and the default `/etc/systemd/system/` folder

