### PR TITLE
Closes #413

### DIFF
--- a/sztp-agent/cmd/cli.go
+++ b/sztp-agent/cmd/cli.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"log"
+	"os"
+
+	"github.com/TwiN/go-color"
+	"github.com/spf13/cobra"
+)
+
+// commands hold a slice of all cobra commands for cli tool
+var commands []*cobra.Command
+
+// RootCmd is the main entrypoint for the cli
+func RootCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "opi-sztp-agent",
+		Short: "opi-sztp-agent is the agent command line interface to work with the sztp workflow",
+		Run: func(cmd *cobra.Command, _ []string) {
+			err := cmd.Help()
+			if err != nil {
+				log.Fatalf(color.InRed("[ERROR]")+"%s", err.Error())
+			}
+			os.Exit(1)
+		},
+	}
+
+	for _, cmd := range commands {
+		c.AddCommand(cmd)
+	}
+
+	return c
+}

--- a/sztp-agent/cmd/daemon.go
+++ b/sztp-agent/cmd/daemon.go
@@ -17,8 +17,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewDaemonCommand returns the daemon command
-func NewDaemonCommand() *cobra.Command {
+//nolint:gochecknoinits
+func init() {
+	commands = append(commands, Daemon())
+}
+
+// Daemon returns the daemon command
+func Daemon() *cobra.Command {
 	var (
 		bootstrapURL             string
 		serialNumber             string
@@ -32,7 +37,7 @@ func NewDaemonCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "daemon",
 		Short: "Run the daemon command",
-		RunE: func(c *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			arrayChecker := []string{devicePrivateKey, deviceEndEntityCert, bootstrapTrustAnchorCert}
 			if bootstrapURL != "" && dhcpLeaseFile != "" {
 				return fmt.Errorf("'--bootstrap-url' and '--dhcp-lease-file' are mutualy exclusive")
@@ -54,8 +59,6 @@ func NewDaemonCommand() *cobra.Command {
 					return fmt.Errorf("must not be folder: %q", filePath)
 				}
 			}
-			err := c.Help()
-			cobra.CheckErr(err)
 			a := secureagent.NewAgent(bootstrapURL, serialNumber, dhcpLeaseFile, devicePassword, devicePrivateKey, deviceEndEntityCert, bootstrapTrustAnchorCert)
 			return a.RunCommandDaemon()
 		},

--- a/sztp-agent/cmd/daemon_test.go
+++ b/sztp-agent/cmd/daemon_test.go
@@ -11,19 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestNewDaemonCommand(t *testing.T) {
+func TestDaemonCommand(t *testing.T) {
 	tests := []struct {
 		name string
 		want *cobra.Command
 	}{
 		{
-			name: "TestNewDaemonCommand",
+			name: "TestDaemonCommand",
 			want: &cobra.Command{
 				Use:   "daemon",
 				Short: "Run the daemon command",
-				RunE: func(c *cobra.Command, _ []string) error {
-					err := c.Help()
-					cobra.CheckErr(err)
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			},
@@ -31,8 +29,8 @@ func TestNewDaemonCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewDaemonCommand(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
-				t.Errorf("NewDaemonCommand() = %v, want %v", got, tt.want)
+			if got := Daemon(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
+				t.Errorf("Daemon() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/sztp-agent/cmd/disable.go
+++ b/sztp-agent/cmd/disable.go
@@ -13,8 +13,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewDisableCommand returns the disable command
-func NewDisableCommand() *cobra.Command {
+//nolint:gochecknoinits
+func init() {
+	commands = append(commands, Disable())
+}
+
+// Disable returns the disable command
+func Disable() *cobra.Command {
 	var (
 		bootstrapURL             string
 		serialNumber             string
@@ -28,9 +33,7 @@ func NewDisableCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Run the disable command",
-		RunE: func(c *cobra.Command, _ []string) error {
-			err := c.Help()
-			cobra.CheckErr(err)
+		RunE: func(_ *cobra.Command, _ []string) error {
 			a := secureagent.NewAgent(bootstrapURL, serialNumber, dhcpLeaseFile, devicePassword, devicePrivateKey, deviceEndEntityCert, bootstrapTrustAnchorCert)
 			return a.RunCommandDisable()
 		},

--- a/sztp-agent/cmd/disable_test.go
+++ b/sztp-agent/cmd/disable_test.go
@@ -11,19 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestNewDisableCommand(t *testing.T) {
+func TestDisableCommand(t *testing.T) {
 	tests := []struct {
 		name string
 		want *cobra.Command
 	}{
 		{
-			name: "TestNewDisableCommand",
+			name: "TestDisableCommand",
 			want: &cobra.Command{
 				Use:   "disable",
 				Short: "Run the disable command",
-				RunE: func(c *cobra.Command, _ []string) error {
-					err := c.Help()
-					cobra.CheckErr(err)
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			},
@@ -31,8 +29,8 @@ func TestNewDisableCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewDisableCommand(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
-				t.Errorf("NewDisableCommand() = %v, want %v", got, tt.want)
+			if got := Disable(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
+				t.Errorf("Disable() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/sztp-agent/cmd/enable.go
+++ b/sztp-agent/cmd/enable.go
@@ -13,8 +13,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewEnableCommand returns the enable command
-func NewEnableCommand() *cobra.Command {
+//nolint:gochecknoinits
+func init() {
+	commands = append(commands, Enable())
+}
+
+// Enable returns the enable command
+func Enable() *cobra.Command {
 	var (
 		bootstrapURL             string
 		serialNumber             string
@@ -28,9 +33,7 @@ func NewEnableCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Run the enable command",
-		RunE: func(c *cobra.Command, _ []string) error {
-			err := c.Help()
-			cobra.CheckErr(err)
+		RunE: func(_ *cobra.Command, _ []string) error {
 			a := secureagent.NewAgent(bootstrapURL, serialNumber, dhcpLeaseFile, devicePassword, devicePrivateKey, deviceEndEntityCert, bootstrapTrustAnchorCert)
 			return a.RunCommandEnable()
 		},

--- a/sztp-agent/cmd/enable_test.go
+++ b/sztp-agent/cmd/enable_test.go
@@ -11,19 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestNewEnableCommand(t *testing.T) {
+func TestEnableCommand(t *testing.T) {
 	tests := []struct {
 		name string
 		want *cobra.Command
 	}{
 		{
-			name: "TestNewEnableCommand",
+			name: "TestEnableCommand",
 			want: &cobra.Command{
 				Use:   "enable",
 				Short: "Run the enable command",
-				RunE: func(c *cobra.Command, _ []string) error {
-					err := c.Help()
-					cobra.CheckErr(err)
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			},
@@ -31,8 +29,8 @@ func TestNewEnableCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewEnableCommand(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
-				t.Errorf("NewEnableCommand() = %v, want %v", got, tt.want)
+			if got := Enable(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
+				t.Errorf("Enable() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/sztp-agent/cmd/run.go
+++ b/sztp-agent/cmd/run.go
@@ -17,8 +17,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewRunCommand returns the run command
-func NewRunCommand() *cobra.Command {
+//nolint:gochecknoinits
+func init() {
+	commands = append(commands, Run())
+}
+
+// Run returns the run command
+func Run() *cobra.Command {
 	var (
 		bootstrapURL             string
 		serialNumber             string
@@ -32,7 +37,7 @@ func NewRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Exec the run command",
-		RunE: func(c *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			arrayChecker := []string{devicePrivateKey, deviceEndEntityCert, bootstrapTrustAnchorCert}
 			if bootstrapURL != "" && dhcpLeaseFile != "" {
 				return fmt.Errorf("'--bootstrap-url' and '--dhcp-lease-file' are mutualy exclusive")
@@ -54,8 +59,6 @@ func NewRunCommand() *cobra.Command {
 					return fmt.Errorf("must not be folder: %q", filePath)
 				}
 			}
-			err := c.Help()
-			cobra.CheckErr(err)
 			a := secureagent.NewAgent(bootstrapURL, serialNumber, dhcpLeaseFile, devicePassword, devicePrivateKey, deviceEndEntityCert, bootstrapTrustAnchorCert)
 			return a.RunCommand()
 		},

--- a/sztp-agent/cmd/run_test.go
+++ b/sztp-agent/cmd/run_test.go
@@ -11,19 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestNewRunCommand(t *testing.T) {
+func TestRunCommand(t *testing.T) {
 	tests := []struct {
 		name string
 		want *cobra.Command
 	}{
 		{
-			name: "TestNewRunCommand",
+			name: "TestRunCommand",
 			want: &cobra.Command{
 				Use:   "run",
 				Short: "Exec the run command",
-				RunE: func(c *cobra.Command, _ []string) error {
-					err := c.Help()
-					cobra.CheckErr(err)
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			},
@@ -31,8 +29,8 @@ func TestNewRunCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewRunCommand(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
-				t.Errorf("NewRunCommand() = %v, want %v", got, tt.want)
+			if got := Run(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
+				t.Errorf("Run() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/sztp-agent/cmd/status.go
+++ b/sztp-agent/cmd/status.go
@@ -13,8 +13,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewStatusCommand returns the status command
-func NewStatusCommand() *cobra.Command {
+//nolint:gochecknoinits
+func init() {
+	commands = append(commands, Status())
+}
+
+// Status returns the status command
+func Status() *cobra.Command {
 	var (
 		bootstrapURL             string
 		serialNumber             string
@@ -28,9 +33,7 @@ func NewStatusCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Run the status command",
-		RunE: func(c *cobra.Command, _ []string) error {
-			err := c.Help()
-			cobra.CheckErr(err)
+		RunE: func(_ *cobra.Command, _ []string) error {
 			a := secureagent.NewAgent(bootstrapURL, serialNumber, dhcpLeaseFile, devicePassword, devicePrivateKey, deviceEndEntityCert, bootstrapTrustAnchorCert)
 			return a.RunCommandStatus()
 		},

--- a/sztp-agent/cmd/status_test.go
+++ b/sztp-agent/cmd/status_test.go
@@ -11,19 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestNewStatusCommand(t *testing.T) {
+func TestStatusCommand(t *testing.T) {
 	tests := []struct {
 		name string
 		want *cobra.Command
 	}{
 		{
-			name: "TestNewStatusCommand",
+			name: "TestStatusCommand",
 			want: &cobra.Command{
 				Use:   "status",
 				Short: "Run the status command",
-				RunE: func(c *cobra.Command, _ []string) error {
-					err := c.Help()
-					cobra.CheckErr(err)
+				RunE: func(_ *cobra.Command, _ []string) error {
 					return nil
 				},
 			},
@@ -31,8 +29,8 @@ func TestNewStatusCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewStatusCommand(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
-				t.Errorf("NewStatusCommand() = %v, want %v", got, tt.want)
+			if got := Status(); !reflect.DeepEqual(got.Commands(), tt.want.Commands()) {
+				t.Errorf("Status() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/sztp-agent/main.go
+++ b/sztp-agent/main.go
@@ -13,36 +13,10 @@ import (
 	"github.com/opiproject/sztp/sztp-agent/cmd"
 
 	"log"
-	"os"
-
-	"github.com/spf13/cobra"
 )
 
 func main() {
-	command := newCommand()
-	if err := command.Execute(); err != nil {
+	if err := cmd.RootCmd().Execute(); err != nil {
 		log.Fatalf(color.InRed("[ERROR]")+"%s", err.Error())
 	}
-}
-
-func newCommand() *cobra.Command {
-	c := &cobra.Command{
-		Use:   "opi-sztp-agent",
-		Short: "opi-sztp-agent is the agent command line interface to work with the sztp workflow",
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				log.Fatalf(color.InRed("[ERROR]")+"%s", err.Error())
-			}
-			os.Exit(1)
-		},
-	}
-
-	c.AddCommand(cmd.NewDaemonCommand())
-	c.AddCommand(cmd.NewRunCommand())
-	c.AddCommand(cmd.NewStatusCommand())
-	c.AddCommand(cmd.NewEnableCommand())
-	c.AddCommand(cmd.NewDisableCommand())
-
-	return c
 }


### PR DESCRIPTION
This PR fixes #413 

I know that using `init()` funcs are not the ideal approach in most cases and is often disregarded and recommended against in Go. But, for the Cobra CLI and the structure of the current source I thought it be necessary for specific reasons. Cobra also recommend this way.

However, I did this a little different to try to avoid the problems with `init()` as much as possible.

Comparatively to the original issue #413:
1. Global slice of `*cobra.command` for the `cmd` pkg 
2. Each command file has an `init()` function that appends the command to the global slice, this is separate from the command functions themselves

This way, we kept the original structure of the command functions so that `init()` doesn't interfere with the testing of the commands. And, if need be, the functions can be used elsewhere.

I decided this was the better approach for `init()` to make it only valuable for the command slice, and not replace the functions directly with `init()`.

I have also renamed the functions for simpler naming, rather than `NewXCommand`, we just use the command name directly as the function name. So for the `disable` command it's now `func Disable()`. I decided this was a nicer change as everything inside `cmd` is obvious it's for the CLI and not for anything else. 

There is a new file `cli.go` inside `cmd` which is handling everything primarily cli related. Only `main` is used to call the root command which sets up everything else.

I've removed the `checkErr(err)` from each command as well, as we have `RunE()` functions on every command, so they always return the error and will always return back to the root command caller and print from there. This stops the issue with double printing the error text and help text unnecessarily. If we need formatted results we can just format an error and return it. 

I've ensured all commits are signed off and have the correct naming, linter passed all checks locally as well.

Let me know if you would like anything amended here! 