### PR TITLE
refactor: rename getBootstrapURL to discoverBootstrapURLs

### DIFF
--- a/sztp-agent/pkg/secureagent/daemon.go
+++ b/sztp-agent/pkg/secureagent/daemon.go
@@ -57,7 +57,7 @@ func (a *Agent) RunCommandDaemon() error {
 func (a *Agent) performBootstrapSequence() error {
 	var err error
 	if a.GetBootstrapURL() == "" {
-		err = a.getBootstrapURL()
+		err = a.discoverBootstrapURLs()
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func (a *Agent) performBootstrapSequence() error {
 	return nil
 }
 
-func (a *Agent) getBootstrapURL() error {
+func (a *Agent) discoverBootstrapURLs() error {
 	log.Println("[INFO] Get the Bootstrap URL from DHCP client")
 	var line string
 	if _, err := os.Stat(a.DhcpLeaseFile); err == nil {

--- a/sztp-agent/pkg/secureagent/daemon_test.go
+++ b/sztp-agent/pkg/secureagent/daemon_test.go
@@ -31,7 +31,7 @@ const DHCPTestContent = `lease {
 }`
 
 //nolint:funlen
-func TestAgent_getBootstrapURL(t *testing.T) {
+func TestAgent_discoverBootstrapURLs(t *testing.T) {
 	dhcpTestFileOK := "/tmp/test.dhcp"
 	createTempTestFile(dhcpTestFileOK, DHCPTestContent, true)
 
@@ -95,7 +95,7 @@ func TestAgent_getBootstrapURL(t *testing.T) {
 				InputJSONContent:         tt.fields.InputJSONContent,
 				DhcpLeaseFile:            tt.fields.DhcpLeasesFile,
 			}
-			if err := a.getBootstrapURL(); (err != nil) != tt.wantErr {
+			if err := a.discoverBootstrapURLs(); (err != nil) != tt.wantErr {
 				t.Errorf("runDaemon() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
this better reflects what function is doing.
and it separates from public `GetBootstrapURL` func

`discoverBootstrapURLs` retrieves URLs from dhcp lease file

In the next patches it will also fetch them from network manager

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>

<!--  Thanks for sending a pull request!  -->

## Proposed changes

Summarize your changes here to communicate with the maintainers and make sure to put the link of that issue

## Types of changes

What types of changes does your code introduce to the repo? Put an `x` in the boxes that apply
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [ ] I have signed the commit for DCO to be passed.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Dependency
- Please add the links to the dependent PR need to be merged before this (if any).

## Special notes for your reviewer:
